### PR TITLE
DEV-2072 calculate file type of watchfolder message

### DIFF
--- a/app/helpers/events.py
+++ b/app/helpers/events.py
@@ -10,6 +10,20 @@ class InvalidMessageException(Exception):
     pass
 
 
+class SIPItem:
+    """Class representing the information of a SIP item
+
+    This is a composite part of the watchfolder message.
+
+    Args:
+        message: The SIP item.
+    """
+
+    def __init__(self, sip_item: dict):
+        self.file_name = sip_item["file_name"]
+        self.file_path = sip_item["file_path"]
+
+
 class WatchfolderMessage:
     """Class representing an incoming watchfolder message
 
@@ -25,18 +39,37 @@ class WatchfolderMessage:
         try:
             self.cp_name = msg["cp_name"]
             self.flow_id = msg["flow_id"]
-            self.essence_file = SIPItem(msg["sip_package"][0])
-            self.xml_file = SIPItem(msg["sip_package"][1])
+            self.files = {}
+            for sip_package in msg["sip_package"]:
+                self.files[sip_package["file_type"]] = SIPItem(sip_package)
+
         except KeyError as e:
             raise InvalidMessageException(f"Missing mandatory key: {e}")
+
+    def _get_file(self, file_type: str) -> SIPItem:
+        """Return the SIPItem of a file in the incoming SIP.
+
+        Only the type 'sidecar' or 'essence' is allowed.
+
+        Args:
+            file_type: The type of the file.
+
+        Returns: The SIPItem.
+        """
+        try:
+            return self.files[file_type]
+        except KeyError:
+            raise ValueError(
+                "Not a valid file type of the incoming SIP: {file_type}. Only 'sidecar' or 'essence' is allowed"
+            )
 
     def get_essence_path(self) -> Path:
         """Return the path of the essence file.
 
         Returns: The essence file as a Path.
         """
-
-        return Path(self.essence_file.file_path, self.essence_file.file_name)
+        file = self._get_file("essence")
+        return Path(file.file_path, file.file_name)
 
     def get_xml_path(self) -> Path:
         """Return the path of the metadata file.
@@ -44,18 +77,5 @@ class WatchfolderMessage:
         Returns: The metadata file as a Path.
         """
 
-        return Path(self.xml_file.file_path, self.xml_file.file_name)
-
-
-class SIPItem:
-    """Class representing the information of a SIP item
-
-    This is a composite part of the watchfolder message.
-
-    Args:
-        message: The SIP item.
-    """
-
-    def __init__(self, sip_item: dict):
-        self.file_name = sip_item["file_name"]
-        self.file_path = sip_item["file_path"]
+        file = self._get_file("sidecar")
+        return Path(file.file_path, file.file_name)

--- a/tests/helpers/test_events.py
+++ b/tests/helpers/test_events.py
@@ -20,12 +20,12 @@ def test_message_valid():
     event = WatchfolderMessage(_load_resource("message.json"))
     assert event.cp_name == "CPFIELD"
     assert event.flow_id == "FLOWFIELD"
-    essence_file = event.essence_file
+    essence_file = event._get_file("essence")
     assert essence_file.file_name == "file.mxf"
     assert essence_file.file_path == "/path/to/essence/file"
 
-    xml_file = event.xml_file
-    assert xml_file.file_name == "file.mxf.xml"
+    xml_file = event._get_file("sidecar")
+    assert xml_file.file_name == "file.xml"
     assert xml_file.file_path == "/path/to/xml/file"
 
 
@@ -42,3 +42,13 @@ def test_message_missing_key():
     with pytest.raises(InvalidMessageException) as e:
         WatchfolderMessage(_load_resource("message_missing_cp_name.json"))
     assert str(e.value) == "Missing mandatory key: 'cp_name'"
+
+
+def test_get_essence_path():
+    event = WatchfolderMessage(_load_resource("message.json"))
+    assert event.get_essence_path() == Path("/path/to/essence/file/file.mxf")
+
+
+def test_get_xml_path():
+    event = WatchfolderMessage(_load_resource("message.json"))
+    assert event.get_xml_path() == Path("/path/to/xml/file/file.xml")

--- a/tests/resources/watchfolder/message.json
+++ b/tests/resources/watchfolder/message.json
@@ -14,7 +14,7 @@
             "timestamp": "2017-09-01T16:23:30.084+02:00"
         },
         {
-            "file_name": "file.mxf.xml",
+            "file_name": "file.xml",
             "file_path": "/path/to/xml/file",
             "file_type": "sidecar",
             "md5": "1",

--- a/tests/resources/watchfolder/message_missing_cp_name.json
+++ b/tests/resources/watchfolder/message_missing_cp_name.json
@@ -13,7 +13,7 @@
             "timestamp": "2017-09-01T16:23:30.084+02:00"
         },
         {
-            "file_name": "file.mxf.xml",
+            "file_name": "file.xml",
             "file_path": "/path/to/xml/file",
             "file_type": "sidecar",
             "md5": "1",


### PR DESCRIPTION
It was assumed that the first entry in the `sip_package` of the watchfolder
message was the essence file and the second one was the XML file. This isn't
necessarily the case. Now, we calculate it via the `file_type` of said file
entry.