### PR TITLE
DEV-2073 Add extra fields to payload cloudevent

### DIFF
--- a/app/helpers/sidecar.py
+++ b/app/helpers/sidecar.py
@@ -15,8 +15,9 @@ class Sidecar:
         self.cp_id = self.root.findtext("CP_id")
         self.dc_source = self.root.findtext("dc_source")
         self.local_id_filename = self.root.findtext(
-            "dc_identifiers_localids/bestandsnaam"
+            "dc_identifier_localids/bestandsnaam"
         )
+        self.local_id = self.root.findtext("dc_identifier_localid")
 
     def calculate_original_filename(self) -> Optional[str]:
         """Calculate the original filename

--- a/tests/resources/sidecar/sidecar_bestandsnaam.xml
+++ b/tests/resources/sidecar/sidecar_bestandsnaam.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <VIAA xmlns:xalan="http://xml.apache.org">
-    <dc_identifiers_localids>
+    <dc_identifier_localids>
         <bestandsnaam>bestandsnaam</bestandsnaam>
-    </dc_identifiers_localids>
+    </dc_identifier_localids>
 </VIAA>

--- a/tests/resources/sidecar/sidecar_bestandsnaam_source.xml
+++ b/tests/resources/sidecar/sidecar_bestandsnaam_source.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <VIAA xmlns:xalan="http://xml.apache.org">
     <dc_source>source</dc_source>
-    <dc_identifiers_localids>
+    <dc_identifier_localids>
         <bestandsnaam>bestandsnaam</bestandsnaam>
-    </dc_identifiers_localids>
+    </dc_identifier_localids>
 </VIAA>


### PR DESCRIPTION
Fields added:
 - Filename of the essence
 - The md5 hash of the essence
 - The CP ID as defined in the watchfolder message
 - The local ID as defined in the sidecar XML
 - The filesize of the essence
 - The filesize of the zipped bag

The `local_id` is also parsed in the sidecar in order to add it to the
payload of the cloudevent.

Also, the field `dc_identifiers_localids` should be `dc_identifier_localids`
resulting in incorrect parsing of `bestandsnaam`.