### PR TITLE
DEV-2081 Copy essence when creating the meemoo SIP

### DIFF
--- a/app/helpers/bag.py
+++ b/app/helpers/bag.py
@@ -401,8 +401,8 @@ def create_sip_bag(
     # /representations/representation_1/data/
     representations_data_folder = representations_folder.joinpath("data")
     representations_data_folder.mkdir(exist_ok=True)
-    # Move essence
-    essence_path.replace(representations_data_folder.joinpath(essence_path.name))
+    # Copy essence
+    shutil.copy(essence_path, representations_data_folder.joinpath(essence_path.name))
 
     # representations/representation_1/metadata/
     representations_metadata_folder = representations_folder.joinpath("metadata")


### PR DESCRIPTION
The meemoo SIP bag folder gets removed after successfully zipping that bag.
That zipped bag gets removed by the `sipin-delete-service` after a successful
transfer of the zipped bag. The essence, however should remain on the FTP
until after a successful ingest of the essence in the MAM. Copying the essence
to the bag folder instead of moving it ensures that the essence stays on
the FTP as the `sipin-delete-service` deletes the original essence and sidecar
after successful ingest.