### PR TITLE
DEV-2102 Run SIP creation in separate thread

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -64,7 +64,6 @@ class EventListener:
         - Send a cloudevent to a Pulsar topic.
         """
         try:
-            self.log.debug(f"Incoming event: {body}")
             # Parse watchfolder
             message = WatchfolderMessage(body)
 

--- a/main.py
+++ b/main.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+from signal import signal, SIGTERM
 
 from app.app import EventListener
 
 if __name__ == "__main__":
     event_listener = EventListener()
+    signal(SIGTERM, event_listener.exit_gracefully)
     event_listener.start()


### PR DESCRIPTION
Creating the SIP potentially takes a long time to finish. As this is
blocking the RabbitMQ I/O loop, this might result in a heartbeat
timeout and the rabbit broker closing the connection on its end.

A possibility would be to set the heartbeat timeout value
to a high enough value or even disable it altogether but this
is seen as a bad practice.

Instead, we run the creation of the SIP in a separate thread making sure
the RabbitMQ I/O loop is not blocked.

The change is based on:
https://github.com/pika/pika/blob/master/examples/basic_consumer_threaded.py

Also, if the application receives a SIGTERM, no new messages should be consumed.
The current tasks should finish and send a (n)ack back. Afterwards, close the
RabbitMQ connection.

Same logic should apply to SIGINT/KeyboardInterrupt.