### PR TITLE
DEV-2107 Calculate title

### DIFF
--- a/app/resources/dcterms.xslt
+++ b/app/resources/dcterms.xslt
@@ -912,7 +912,7 @@
                 <xsl:value-of select="$titles_first" />
             </xsl:element>
         </xsl:if>
-        <xsl:if test="$description_short and not($titles_first and $title)">
+        <xsl:if test="$description_short and not($titles_first or $title)">
             <xsl:element name="dcterms:title">
                 <xsl:value-of select="$description_short" />
             </xsl:element>

--- a/app/resources/dcterms.xslt
+++ b/app/resources/dcterms.xslt
@@ -1,7 +1,14 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:premis="http://www.loc.gov/premis/v3" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api" xsi:schemaLocation="urn:ebu:metadata-schema:ebucore https://www.ebu.ch/metadata/schemas/EBUCore/20171009/ebucore.xsd" version="1.1">
     <xsl:output method="xml" encoding="UTF-8" indent="yes" />
+
+    <!-- vars -->
+    <xsl:variable name="title" select="/VIAA/dc_title" />
+    <xsl:variable name="titles_first" select="/VIAA/dc_titles/*[1]" />
+    <xsl:variable name="description_short" select="/VIAA/dc_description_short" />
+
     <xsl:template match="VIAA">
         <premis:object>
+            <xsl:call-template name="title" />
             <xsl:apply-templates select="*" />
         </premis:object>
     </xsl:template>
@@ -887,11 +894,29 @@
         </xsl:element>
     </xsl:template>
 
-    <!-- Title -->
-    <xsl:template match="dc_title">
-        <xsl:element name="dcterms:title">
-            <xsl:value-of select="text()" />
-        </xsl:element>
+    <!-- Title
+
+    In order:
+     - dc_title
+     - dc_titles/*[1] - first element in dc_titles
+     - dc_short_description
+    -->
+    <xsl:template name="title">
+        <xsl:if test="$title">
+            <xsl:element name="dcterms:title">
+                <xsl:value-of select="$title" />
+            </xsl:element>
+        </xsl:if>
+        <xsl:if test="$titles_first and not($title)">
+            <xsl:element name="dcterms:title">
+                <xsl:value-of select="$titles_first" />
+            </xsl:element>
+        </xsl:if>
+        <xsl:if test="$description_short and not($titles_first and $title)">
+            <xsl:element name="dcterms:title">
+                <xsl:value-of select="$description_short" />
+            </xsl:element>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template match="@*|node()">

--- a/tests/helpers/test_dcterms.py
+++ b/tests/helpers/test_dcterms.py
@@ -34,6 +34,7 @@ from lxml import etree
         ),
         ("metadata_bestandsnamen.xml", "dcterms_bestandsnamen.xml"),
         ("metadata_dc_Subjects.xml", "dcterms_dc_Subjects.xml"),
+        ("metadata_description_short.xml", "dcterms_description_short.xml"),
     ],
 )
 def test_transform(input_file, output_file):

--- a/tests/resources/dcterms/dcterms.xml
+++ b/tests/resources/dcterms/dcterms.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>Dit is een titel</dcterms:title>
   <dcterms:identifier>PID</dcterms:identifier>
   <premis:objectIdentifier>
     <premis:objectIdentifierType>local_id</premis:objectIdentifierType>
@@ -10,7 +11,6 @@
   </premis:objectIdentifier>
   <dcterms:created xsi:type="EDTF-level1">2022-03-29</dcterms:created>
   <dcterms:issued xsi:type="EDTF-level1">2022-03-29</dcterms:issued>
-  <dcterms:title>Dit is een titel</dcterms:title>
   <dcterms:description>Dit is een beschrijving</dcterms:description>
   <schema:genre>Nieuws</schema:genre>
   <schema:genre>Sport</schema:genre>

--- a/tests/resources/dcterms/dcterms_archief.xml
+++ b/tests/resources/dcterms/dcterms_archief.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>Archief</dcterms:title>
   <dcterms:isPartOf xsi:type="schema:ArchiveComponent">
     <dcterms:title>Archief</dcterms:title>
   </dcterms:isPartOf>

--- a/tests/resources/dcterms/dcterms_deelarchief.xml
+++ b/tests/resources/dcterms/dcterms_deelarchief.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>Deelarchief</dcterms:title>
   <dcterms:isPartOf xsi:type="schema:ArchiveComponent">
     <dcterms:hasPart xsi:type="schema:ArchiveComponent">
       <dcterms:title>Deelarchief</dcterms:title>

--- a/tests/resources/dcterms/dcterms_deelreeks.xml
+++ b/tests/resources/dcterms/dcterms_deelreeks.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>Deelreeks</dcterms:title>
   <dcterms:isPartOf xsi:type="schema:CreativeWorkSeries">
     <dcterms:hasPart xsi:type="schema:CreativeWorkSeries">
       <dcterms:title>Deelreeks</dcterms:title>

--- a/tests/resources/dcterms/dcterms_deelreeks_serienummer.xml
+++ b/tests/resources/dcterms/dcterms_deelreeks_serienummer.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>Deelreeks</dcterms:title>
   <dcterms:isPartOf xsi:type="schema:CreativeWorkSeries">
     <dcterms:identifier>2</dcterms:identifier>
     <dcterms:hasPart xsi:type="schema:CreativeWorkSeries">

--- a/tests/resources/dcterms/dcterms_description_short.xml
+++ b/tests/resources/dcterms/dcterms_description_short.xml
@@ -1,6 +1,3 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
-  <dcterms:title>Reeks</dcterms:title>
-  <dcterms:isPartOf xsi:type="schema:CreativeWorkSeries">
-    <dcterms:title>Reeks</dcterms:title>
-  </dcterms:isPartOf>
+  <dcterms:title>Dit is een beschrijving</dcterms:title>
 </premis:object>

--- a/tests/resources/dcterms/dcterms_programma.xml
+++ b/tests/resources/dcterms/dcterms_programma.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>Programma</dcterms:title>
   <dcterms:isPartOf xsi:type="schema:BroadcastEvent">
     <dcterms:title>Programma</dcterms:title>
   </dcterms:isPartOf>

--- a/tests/resources/dcterms/dcterms_reeks_deelreeks.xml
+++ b/tests/resources/dcterms/dcterms_reeks_deelreeks.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>Reeks</dcterms:title>
   <dcterms:isPartOf xsi:type="schema:CreativeWorkSeries">
     <dcterms:title>Reeks</dcterms:title>
     <dcterms:hasPart xsi:type="schema:CreativeWorkSeries">

--- a/tests/resources/dcterms/dcterms_reeks_serienummer.xml
+++ b/tests/resources/dcterms/dcterms_reeks_serienummer.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>Reeks</dcterms:title>
   <dcterms:isPartOf xsi:type="schema:CreativeWorkSeries">
     <dcterms:title>Reeks</dcterms:title>
     <dcterms:identifier>2</dcterms:identifier>

--- a/tests/resources/dcterms/dcterms_seizoen.xml
+++ b/tests/resources/dcterms/dcterms_seizoen.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>Seizoen</dcterms:title>
   <dcterms:isPartOf xsi:type="schema:CreativeWorkSeason">
     <dcterms:title>Seizoen</dcterms:title>
   </dcterms:isPartOf>

--- a/tests/resources/dcterms/dcterms_seizoennummer.xml
+++ b/tests/resources/dcterms/dcterms_seizoennummer.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>1</dcterms:title>
   <dcterms:isPartOf xsi:type="schema:CreativeWorkSeason">
     <schema:seasonNumber>1</schema:seasonNumber>
   </dcterms:isPartOf>

--- a/tests/resources/dcterms/dcterms_serie.xml
+++ b/tests/resources/dcterms/dcterms_serie.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>Serie</dcterms:title>
   <dcterms:isPartOf xsi:type="schema:CreativeWorkSeries">
     <dcterms:title>Serie</dcterms:title>
   </dcterms:isPartOf>

--- a/tests/resources/dcterms/dcterms_serie_deelreeks.xml
+++ b/tests/resources/dcterms/dcterms_serie_deelreeks.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>Serie</dcterms:title>
   <dcterms:isPartOf xsi:type="schema:CreativeWorkSeries">
     <dcterms:title>Serie</dcterms:title>
     <dcterms:hasPart xsi:type="schema:CreativeWorkSeries">

--- a/tests/resources/dcterms/dcterms_serie_serienummer.xml
+++ b/tests/resources/dcterms/dcterms_serie_serienummer.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>Serie</dcterms:title>
   <dcterms:isPartOf xsi:type="schema:CreativeWorkSeries">
     <dcterms:title>Serie</dcterms:title>
     <dcterms:identifier>2</dcterms:identifier>

--- a/tests/resources/dcterms/dcterms_serienummer.xml
+++ b/tests/resources/dcterms/dcterms_serienummer.xml
@@ -1,4 +1,5 @@
 <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+  <dcterms:title>2</dcterms:title>
   <dcterms:isPartOf xsi:type="schema:CreativeWorkSeries">
     <dcterms:identifier>2</dcterms:identifier>
   </dcterms:isPartOf>

--- a/tests/resources/dcterms/metadata.xml
+++ b/tests/resources/dcterms/metadata.xml
@@ -12,6 +12,8 @@
     <dcterms_issued>2022-03-29</dcterms_issued>
     <dc_title>Dit is een titel</dc_title>
     <dc_description>Dit is een beschrijving</dc_description>
+    <!-- ignore -->
+    <dc_description_short>Dit is een korte beschrijving</dc_description_short>
     <dc_types type="list" strategy="OVERWRITE">
         <multiselect>Nieuws</multiselect>
         <multiselect>Sport</multiselect>

--- a/tests/resources/dcterms/metadata_description_short.xml
+++ b/tests/resources/dcterms/metadata_description_short.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VIAA>
+    <dc_description_short>Dit is een beschrijving</dc_description_short>
+</VIAA>


### PR DESCRIPTION
Although `/VIAA/dc_title` is mandatory, it might be absent from some
sidecars of some CPs. Implement a kind of fallback mechanism based on
the previous borndigital logic.

Use in order:
 - `/VIAA/dc_title`
  -`/VIAA/dc_titles/*[1]`
 - `/VIAA/dc_description_short`