### PR TITLE
DEV-2110 Changes to `dc_contributors`

### DIFF
--- a/app/resources/dcterms.xslt
+++ b/app/resources/dcterms.xslt
@@ -13,11 +13,38 @@
         </premis:object>
     </xsl:template>
 
-    <!-- Creators -->
+    <!-- Contributors -->
+    <xsl:template match="dc_contributors/Aanwezig">
+        <xsl:element name="dcterms:contributor">
+            <xsl:attribute name="schema:roleName">
+                <xsl:text>aanwezig</xsl:text>
+            </xsl:attribute>
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+
     <xsl:template match="dc_contributors/Adviseur">
         <xsl:element name="dcterms:contributor">
             <xsl:attribute name="schema:roleName">
                 <xsl:text>adviseur</xsl:text>
+            </xsl:attribute>
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="dc_contributors/Afwezig">
+        <xsl:element name="dcterms:contributor">
+            <xsl:attribute name="schema:roleName">
+                <xsl:text>afwezig</xsl:text>
+            </xsl:attribute>
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="dc_contributors/Archivaris">
+        <xsl:element name="dcterms:contributor">
+            <xsl:attribute name="schema:roleName">
+                <xsl:text>archivaris</xsl:text>
             </xsl:attribute>
             <xsl:value-of select="text()" />
         </xsl:element>
@@ -110,10 +137,19 @@
         </xsl:element>
     </xsl:template>
 
-    <xsl:template match="dc_contributors/Decorontwerper">
+    <xsl:template match="dc_contributors/DecorOntwerper">
         <xsl:element name="dcterms:contributor">
             <xsl:attribute name="schema:roleName">
                 <xsl:text>decorontwerper</xsl:text>
+            </xsl:attribute>
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="dc_contributors/Digitaliseringspartner">
+        <xsl:element name="dcterms:contributor">
+            <xsl:attribute name="schema:roleName">
+                <xsl:text>digitaliseringspartner</xsl:text>
             </xsl:attribute>
             <xsl:value-of select="text()" />
         </xsl:element>
@@ -123,6 +159,15 @@
         <xsl:element name="dcterms:contributor">
             <xsl:attribute name="schema:roleName">
                 <xsl:text>dirigent</xsl:text>
+            </xsl:attribute>
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="dc_contributors/Dramaturg">
+        <xsl:element name="dcterms:contributor">
+            <xsl:attribute name="schema:roleName">
+                <xsl:text>dramaturg</xsl:text>
             </xsl:attribute>
             <xsl:value-of select="text()" />
         </xsl:element>
@@ -146,7 +191,25 @@
         </xsl:element>
     </xsl:template>
 
-    <xsl:template match="dc_contributors/Kostuumontwerper">
+    <xsl:template match="dc_contributors/Geluidsman">
+        <xsl:element name="dcterms:contributor">
+            <xsl:attribute name="schema:roleName">
+                <xsl:text>geluidsman</xsl:text>
+            </xsl:attribute>
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="dc_contributors/GrafischOntwerper">
+        <xsl:element name="dcterms:contributor">
+            <xsl:attribute name="schema:roleName">
+                <xsl:text>grafisch_ontwerper</xsl:text>
+            </xsl:attribute>
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="dc_contributors/KostuumOntwerper">
         <xsl:element name="dcterms:contributor">
             <xsl:attribute name="schema:roleName">
                 <xsl:text>kostuumontwerper</xsl:text>
@@ -263,7 +326,7 @@
         </xsl:element>
     </xsl:template>
 
-    <xsl:template match="dc_contributors/Technischadviseur">
+    <xsl:template match="dc_contributors/TechnischAdviseur">
         <xsl:element name="dcterms:contributor">
             <xsl:attribute name="schema:roleName">
                 <xsl:text>technisch_adviseur</xsl:text>
@@ -276,6 +339,15 @@
         <xsl:element name="dcterms:contributor">
             <xsl:attribute name="schema:roleName">
                 <xsl:text>uitvoerder</xsl:text>
+            </xsl:attribute>
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="dc_contributors/Verontschuldigd">
+        <xsl:element name="dcterms:contributor">
+            <xsl:attribute name="schema:roleName">
+                <xsl:text>verontschuldigd</xsl:text>
             </xsl:attribute>
             <xsl:value-of select="text()" />
         </xsl:element>
@@ -294,6 +366,15 @@
         <xsl:element name="dcterms:contributor">
             <xsl:attribute name="schema:roleName">
                 <xsl:text>verteller</xsl:text>
+            </xsl:attribute>
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="dc_contributors/Voorzitter">
+        <xsl:element name="dcterms:contributor">
+            <xsl:attribute name="schema:roleName">
+                <xsl:text>voorzitter</xsl:text>
             </xsl:attribute>
             <xsl:value-of select="text()" />
         </xsl:element>

--- a/tests/resources/dcterms/dcterms.xml
+++ b/tests/resources/dcterms/dcterms.xml
@@ -41,7 +41,10 @@
   <dcterms:publisher>Publisher</dcterms:publisher>
   <dcterms:language>Nederlands</dcterms:language>
   <dcterms:language>Engels</dcterms:language>
+  <dcterms:contributor schema:roleName="aanwezig">Aanwezig</dcterms:contributor>
   <dcterms:contributor schema:roleName="adviseur">Adviseur</dcterms:contributor>
+  <dcterms:contributor schema:roleName="afwezig">Afwezig</dcterms:contributor>
+  <dcterms:contributor schema:roleName="archivaris">Archivaris</dcterms:contributor>
   <dcterms:contributor schema:roleName="arrangeur">Arrangeur</dcterms:contributor>
   <dcterms:contributor schema:roleName="artistiek_directeur">Artistiek directeur</dcterms:contributor>
   <dcterms:contributor schema:roleName="assistent">Assistent</dcterms:contributor>
@@ -53,9 +56,13 @@
   <dcterms:contributor schema:roleName="commentator">Commentator</dcterms:contributor>
   <dcterms:contributor schema:roleName="componist">Componist</dcterms:contributor>
   <dcterms:contributor schema:roleName="decorontwerper">Decorontwerper</dcterms:contributor>
+  <dcterms:contributor schema:roleName="digitaliseringspartner">Digitaliseringspartner</dcterms:contributor>
   <dcterms:contributor schema:roleName="dirigent">Dirigent</dcterms:contributor>
+  <dcterms:contributor schema:roleName="dramaturg">Dramaturg</dcterms:contributor>
   <dcterms:contributor schema:roleName="fotografie">Fotografie</dcterms:contributor>
   <dcterms:contributor schema:roleName="geluid">Geluid</dcterms:contributor>
+  <dcterms:contributor schema:roleName="geluidsman">Geluidsman</dcterms:contributor>
+  <dcterms:contributor schema:roleName="grafisch_ontwerper">Grafisch ontwerper</dcterms:contributor>
   <dcterms:contributor schema:roleName="kostuumontwerper">Kostuumontwerper</dcterms:contributor>
   <dcterms:contributor schema:roleName="kunstenaar">Kunstenaar</dcterms:contributor>
   <dcterms:contributor schema:roleName="make-up">Make-up</dcterms:contributor>
@@ -71,8 +78,10 @@
   <dcterms:contributor schema:roleName="sponsor">Sponsor</dcterms:contributor>
   <dcterms:contributor schema:roleName="technisch_adviseur">Technisch adviseur</dcterms:contributor>
   <dcterms:contributor schema:roleName="uitvoerder">Uitvoerder</dcterms:contributor>
+  <dcterms:contributor schema:roleName="verontschuldigd">Verontschuldigd</dcterms:contributor>
   <dcterms:contributor schema:roleName="vertaler">Vertaler</dcterms:contributor>
   <dcterms:contributor schema:roleName="verteller">Verteller</dcterms:contributor>
+  <dcterms:contributor schema:roleName="voorzitter">Voorzitter</dcterms:contributor>
   <dcterms:creator schema:roleName="acteur">Acteur</dcterms:creator>
   <dcterms:creator schema:roleName="archiefvormer">Archiefvormer</dcterms:creator>
   <dcterms:creator schema:roleName="auteur">Auteur</dcterms:creator>

--- a/tests/resources/dcterms/metadata.xml
+++ b/tests/resources/dcterms/metadata.xml
@@ -64,7 +64,10 @@
         <multiselect>Engels</multiselect>
     </dc_languages>
     <dc_contributors>
+        <Aanwezig>Aanwezig</Aanwezig>
         <Adviseur>Adviseur</Adviseur>
+        <Afwezig>Afwezig</Afwezig>
+        <Archivaris>Archivaris</Archivaris>
         <Arrangeur>Arrangeur</Arrangeur>
         <ArtistiekDirecteur>Artistiek directeur</ArtistiekDirecteur>
         <Assistent>Assistent</Assistent>
@@ -75,11 +78,15 @@
         <Co-producer>Coproducer</Co-producer>
         <Commentator>Commentator</Commentator>
         <Componist>Componist</Componist>
-        <Decorontwerper>Decorontwerper</Decorontwerper>
+        <DecorOntwerper>Decorontwerper</DecorOntwerper>
+        <Digitaliseringspartner>Digitaliseringspartner</Digitaliseringspartner>
         <Dirigent>Dirigent</Dirigent>
+        <Dramaturg>Dramaturg</Dramaturg>
         <Fotografie>Fotografie</Fotografie>
         <Geluid>Geluid</Geluid>
-        <Kostuumontwerper>Kostuumontwerper</Kostuumontwerper>
+        <Geluidsman>Geluidsman</Geluidsman>
+        <GrafischOntwerper>Grafisch ontwerper</GrafischOntwerper>
+        <KostuumOntwerper>Kostuumontwerper</KostuumOntwerper>
         <Kunstenaar>Kunstenaar</Kunstenaar>
         <Make-up>Make-up</Make-up>
         <Muzikant>Muzikant</Muzikant>
@@ -92,10 +99,12 @@
         <Scenarist>Scenarist</Scenarist>
         <Soundtrack>Soundtrack</Soundtrack>
         <Sponsor>Sponsor</Sponsor>
-        <Technischadviseur>Technisch adviseur</Technischadviseur>
+        <TechnischAdviseur>Technisch adviseur</TechnischAdviseur>
         <Uitvoerder>Uitvoerder</Uitvoerder>
+        <Verontschuldigd>Verontschuldigd</Verontschuldigd>
         <Vertaler>Vertaler</Vertaler>
         <Verteller>Verteller</Verteller>
+        <Voorzitter>Voorzitter</Voorzitter>
     </dc_contributors>
     <dc_creators>
         <Acteur>Acteur</Acteur>


### PR DESCRIPTION
Added the following missing contributors:
 - Aanwezig
 - Afwezig
 - Archivaris
 - Digitaliseringspartner
 - Dramaturg
 - Geluidsman
 - GrafischOntwerper
 - Verontschuldigd
 - Voorzitter

Some fields were not according to the VIAA metadatamodel spec:
 - Decorontwerper -> DecorOntwerper
 - Kostuumontwerper -> KostuumOntwerper
 - Technischadviseur -> TechnischAdviseur