### PR TITLE
DEV-2169 Map batch_id

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -129,6 +129,10 @@ class EventListener:
                 "md5_hash_essence_sidecar": sidecar.md5,
             }
 
+            # Add batch ID if available
+            if sidecar.batch_id:
+                data["batch_id"] = sidecar.batch_id
+
             if md5_hash_essence_manifest != sidecar.md5:
                 self.log.error(
                     f"Supplied MD5 differs from the calculated MD5.",

--- a/app/helpers/bag.py
+++ b/app/helpers/bag.py
@@ -648,8 +648,14 @@ class Bag:
             str(root_folder.joinpath("mets.xml")), pretty_print=True
         )
 
+        # Bag
+        # Bag info
+        bag_info = {}
+        if self.sidecar.batch_id:
+            bag_info["Meemoo-Batch-Identifier"] = self.sidecar.batch_id
+
         # Make bag
-        bag = bagit.make_bag(root_folder, checksums=["md5"])
+        bag = bagit.make_bag(root_folder, bag_info=bag_info, checksums=["md5"])
 
         # Zip bag
         bag_path = root_folder.with_suffix(".bag.zip")

--- a/app/helpers/sidecar.py
+++ b/app/helpers/sidecar.py
@@ -37,6 +37,8 @@ class Sidecar:
         self.player_manufacturer = self.root.findtext("player_manufacturer")
         self.player_serial_number = self.root.findtext("player_serial_number")
         self.player_model = self.root.findtext("player_model")
+        # Batch ID
+        self.batch_id = self.root.findtext("batch_id")
 
     def calculate_original_filename(self) -> Optional[str]:
         """Calculate the original filename

--- a/tests/helpers/test_sidecar.py
+++ b/tests/helpers/test_sidecar.py
@@ -47,3 +47,8 @@ def test_sidecar_xdcam():
     assert sidecar.sp_name == "SP Name"
     assert sidecar.type_viaa == "Video"
     assert sidecar.is_xdcam() is True
+
+
+def test_sidecar_batch_id():
+    sidecar = Sidecar(Path("tests", "resources", "sidecar", "sidecar_batch_id.xml"))
+    assert sidecar.batch_id == "Batch ID"

--- a/tests/resources/sidecar/sidecar_batch_id.xml
+++ b/tests/resources/sidecar/sidecar_batch_id.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<VIAA xmlns:xalan="http://xml.apache.org">
+    <batch_id>Batch ID</batch_id>
+</VIAA>


### PR DESCRIPTION
There is a metadata field `batch_id` which is used by the batch intake
process to group a batch of items. Although this is just a logical grouping
identifier it is an important one as it is used for reporting and such.

We map the `batch_id` on the bag level and not the SIP itself. We map the ID
to a "meemoo internal identifier" in the `bag-info.txt`.