### PR TITLE
DEV-2181 Make md5 check case-insensitive

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -129,14 +129,14 @@ class EventListener:
                 "md5_hash_essence_sidecar": sidecar.md5,
             }
 
-            if md5_hash_essence_manifest != sidecar.md5:
+            if md5_hash_essence_manifest != sidecar.md5.lower():
                 self.log.error(
-                    f"Supplied MD5 differs from the calculated MD5.",
-                    sidecar_md5=sidecar.md5,
+                    "Supplied MD5 differs from the calculated MD5.",
+                    sidecar_md5=sidecar.md5.lower(),
                     manifest_md5=md5_hash_essence_manifest,
                 )
                 data["outcome"] = EventOutcome.FAIL.to_str()
-                data["message"] = f"Supplied MD5 differs from the calculated MD5."
+                data["message"] = "Supplied MD5 differs from the calculated MD5."
 
             outgoing_event = Event(attributes, data)
 


### PR DESCRIPTION
The string representation of the supplied md5 hash can be in uppercase.
However, the representation of the calculated essence md5 will only contain
lowercase characters. So, make the identity check between the two md5
values case-insensitive.

Also, remove some unnecessary f-strings.