### PR TITLE
DEV-2184 Validate sidecar XML

### DIFF
--- a/app/helpers/sidecar.py
+++ b/app/helpers/sidecar.py
@@ -6,12 +6,21 @@ from typing import Optional
 from lxml import etree
 
 
+class InvalidSidecarException(Exception):
+    pass
+
+
 class Sidecar:
     """Class used for parsing the metadata sidecar of the essence pair."""
 
     def __init__(self, path: Path):
         self.root = etree.parse(str(path))
+        # Mandatory
         self.md5 = self.root.findtext("md5")
+        if not self.md5:
+            raise InvalidSidecarException("Missing mandatory key: 'md5'")
+
+        # Optional
         self.cp_id = self.root.findtext("CP_id")
         self.dc_source = self.root.findtext("dc_source")
         # Ensure order: Bestandsnaam should have priority over bestandsnaam
@@ -41,7 +50,7 @@ class Sidecar:
         self.batch_id = self.root.findtext("batch_id")
 
     def calculate_original_filename(self) -> Optional[str]:
-        """Calculate the original filename
+        """Calculate the original filename.
 
         Give preference to the "bestandsnaam" field in the "dc_identifiers_localids"
         list. If it doesn't exists, use the value of the 'dc_source' field.
@@ -59,7 +68,7 @@ class Sidecar:
             return None
 
     def is_xdcam(self) -> bool:
-        """Determines if it is XDCAM
+        """Determines if it is XDCAM.
 
         Returns:
             True if XDCAM.

--- a/tests/helpers/test_sidecar.py
+++ b/tests/helpers/test_sidecar.py
@@ -5,19 +5,19 @@ from pathlib import Path
 
 import pytest
 
-from app.helpers.sidecar import Sidecar
+from app.helpers.sidecar import InvalidSidecarException, Sidecar
 
 
 def test_sidecar():
     sidecar = Sidecar(Path("tests", "resources", "sidecar", "sidecar.xml"))
-    assert not sidecar.md5
+    assert sidecar.md5 == "7e0ef8c24fe343d98fbb93b6a7db6ccb"
     assert sidecar.cp_id == "CP ID"
     assert sidecar.is_xdcam() is False
 
 
-def test_sidecar_md5():
-    sidecar = Sidecar(Path("tests", "resources", "sidecar", "sidecar_md5.xml"))
-    assert sidecar.md5 == "7e0ef8c24fe343d98fbb93b6a7db6ccb"
+def test_sidecar_no_md5():
+    with pytest.raises(InvalidSidecarException):
+        Sidecar(Path("tests", "resources", "sidecar", "sidecar_no_md5.xml"))
 
 
 @pytest.mark.parametrize(

--- a/tests/resources/sidecar/sidecar.xml
+++ b/tests/resources/sidecar/sidecar.xml
@@ -3,6 +3,7 @@
     <CP>CP</CP>
     <CP_id>CP ID</CP_id>
     <dc_identifier_localid>localid</dc_identifier_localid>
+    <md5>7e0ef8c24fe343d98fbb93b6a7db6ccb</md5>
     <dc_title>title</dc_title>
     <dcterms_created>2022-01-28</dcterms_created>
     <dc_Subjects type="list">

--- a/tests/resources/sidecar/sidecar_batch_id.xml
+++ b/tests/resources/sidecar/sidecar_batch_id.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <VIAA xmlns:xalan="http://xml.apache.org">
     <batch_id>Batch ID</batch_id>
+    <md5>7e0ef8c24fe343d98fbb93b6a7db6ccb</md5>
 </VIAA>

--- a/tests/resources/sidecar/sidecar_bestandsnaam.xml
+++ b/tests/resources/sidecar/sidecar_bestandsnaam.xml
@@ -3,4 +3,5 @@
     <dc_identifier_localids>
         <bestandsnaam>bestandsnaam</bestandsnaam>
     </dc_identifier_localids>
+    <md5>7e0ef8c24fe343d98fbb93b6a7db6ccb</md5>
 </VIAA>

--- a/tests/resources/sidecar/sidecar_bestandsnaam_source.xml
+++ b/tests/resources/sidecar/sidecar_bestandsnaam_source.xml
@@ -4,4 +4,5 @@
     <dc_identifier_localids>
         <bestandsnaam>bestandsnaam</bestandsnaam>
     </dc_identifier_localids>
+    <md5>7e0ef8c24fe343d98fbb93b6a7db6ccb</md5>
 </VIAA>

--- a/tests/resources/sidecar/sidecar_bestandsnamen_source.xml
+++ b/tests/resources/sidecar/sidecar_bestandsnamen_source.xml
@@ -5,4 +5,5 @@
         <bestandsnaam>bestandsnaam</bestandsnaam>
         <Bestandsnaam>Bestandsnaam</Bestandsnaam>
     </dc_identifier_localids>
+    <md5>7e0ef8c24fe343d98fbb93b6a7db6ccb</md5>
 </VIAA>

--- a/tests/resources/sidecar/sidecar_no_md5.xml
+++ b/tests/resources/sidecar/sidecar_no_md5.xml
@@ -3,7 +3,6 @@
     <CP>CP</CP>
     <CP_id>CP ID</CP_id>
     <dc_identifier_localid>localid</dc_identifier_localid>
-    <md5>7e0ef8c24fe343d98fbb93b6a7db6ccb</md5>
     <dc_title>title</dc_title>
     <dcterms_created>2022-01-28</dcterms_created>
     <dc_Subjects type="list">

--- a/tests/resources/sidecar/sidecar_source.xml
+++ b/tests/resources/sidecar/sidecar_source.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <VIAA xmlns:xalan="http://xml.apache.org">
     <dc_source>source</dc_source>
+    <md5>7e0ef8c24fe343d98fbb93b6a7db6ccb</md5>
 </VIAA>

--- a/tests/resources/sidecar/sidecar_xdcam.xml
+++ b/tests/resources/sidecar/sidecar_xdcam.xml
@@ -3,6 +3,7 @@
     <CP>CP</CP>
     <CP_id>CP ID</CP_id>
     <dc_identifier_localid>localid</dc_identifier_localid>
+    <md5>7e0ef8c24fe343d98fbb93b6a7db6ccb</md5>
     <dc_title>title</dc_title>
     <dcterms_created>2022-01-28</dcterms_created>
     <dc_Subjects type="list">


### PR DESCRIPTION
Add a mechanism to check if the necessary fields in the sidecar are available. If not, log an error, send a failed event to Pulsar and stop the processing. For now, only the md5 is deemed necessary.

Also, if the local_id is not available in the sidecar, do not add it as key/value in the data of the event.