### PR TITLE
DEV-2196 Add .psb extension to mimetype map

### DIFF
--- a/app/helpers/bag.py
+++ b/app/helpers/bag.py
@@ -68,6 +68,7 @@ EXTENSION_MIMETYPE_MAP = {
     ".ts": "video/MP2T",
     ".m4v": "video/mp4",
     ".xml": "application/xml",
+    ".psb": "application/vnd.adobe.photoshop",
 }
 
 MIMETYPE_TYPE_MAP = {
@@ -84,6 +85,7 @@ MIMETYPE_TYPE_MAP = {
     "video/MP2T": "Video - File-based and Physical Media",
     "video/mpeg": "Video - File-based and Physical Media",
     "application/mxf": "Video - File-based and Physical Media",
+    "application/vnd.adobe.photoshop": "Photographs - Digital",
 }
 
 

--- a/tests/helpers/test_bag.py
+++ b/tests/helpers/test_bag.py
@@ -28,6 +28,7 @@ from app.helpers.bag import guess_mimetype, calculate_sip_type
         (".ts", "video/MP2T"),
         (".m4v", "video/mp4"),
         (".xml", "application/xml"),
+        (".psb", "application/vnd.adobe.photoshop"),
     ],
 )
 def test_guess_mimetype(extension, mimetype):
@@ -60,6 +61,7 @@ def test_guess_mimetype_other():
         ("video/MP2T", "Video - File-based and Physical Media"),
         ("video/mpeg", "Video - File-based and Physical Media"),
         ("application/mxf", "Video - File-based and Physical Media"),
+        ("application/vnd.adobe.photoshop", "Photographs - Digital"),
     ],
 )
 def test_calculate_sip_type(mimetype, sip_type):


### PR DESCRIPTION
Although this extension is not allowed in the watchfolders, these files can be send via the batch intake.