### PR TITLE
DEV-2215 Add Meemoo-Workflow in bag-info

### DIFF
--- a/app/helpers/bag.py
+++ b/app/helpers/bag.py
@@ -655,6 +655,8 @@ class Bag:
         bag_info = {}
         if self.sidecar.batch_id:
             bag_info["Meemoo-Batch-Identifier"] = self.sidecar.batch_id
+        if self.sidecar.sp_name == "TAPE":
+            bag_info["Meemoo-Workflow"] = self.sidecar.sp_name
 
         # Make bag
         bag = bagit.make_bag(root_folder, bag_info=bag_info, checksums=["md5"])


### PR DESCRIPTION
There is a very specific case in which the value of the `sp_name` needs to be mapped to the mhs metadata. However, this is an exception, so the mapping is not on the SIP level but on the bag level.

We map the `sp_name` value to the value of the `Meemoo-Workflow` key in the `bag-info.txt`.