### PR TITLE
DEV-2228 Add two extensions to mimetype map

### DIFF
--- a/app/helpers/bag.py
+++ b/app/helpers/bag.py
@@ -69,6 +69,8 @@ EXTENSION_MIMETYPE_MAP = {
     ".m4v": "video/mp4",
     ".xml": "application/xml",
     ".psb": "application/vnd.adobe.photoshop",
+    ".mpeg": "video/mpeg",
+    ".mts": "video/MP2T",
 }
 
 MIMETYPE_TYPE_MAP = {

--- a/tests/helpers/test_bag.py
+++ b/tests/helpers/test_bag.py
@@ -29,6 +29,8 @@ from app.helpers.bag import guess_mimetype, calculate_sip_type
         (".m4v", "video/mp4"),
         (".xml", "application/xml"),
         (".psb", "application/vnd.adobe.photoshop"),
+        (".mpeg", "video/mpeg"),
+        (".mts", "video/MP2T"),
     ],
 )
 def test_guess_mimetype(extension, mimetype):


### PR DESCRIPTION
Add `.mpeg` and `.mts` extensions to the mimetype map. Although these extensions are not allowed in the watchfolders, these files can be send via the batch intake.