### PR TITLE
DEV-2209 Catch XML parse error

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -132,7 +132,7 @@ class EventListener:
         try:
             sidecar = Sidecar(xml_path)
         except InvalidSidecarException as e:
-            self.log.error("Could not create SIP because sidecar was invalid.")
+            self.log.error(f"Could not create SIP because sidecar was invalid. {e}")
             # Create and send cloudevent
             self.send_failed_pulsar_message(attributes, data, f"Sidecar not valid. {e}")
             self.send_nack_message(channel, delivery_tag)

--- a/app/helpers/sidecar.py
+++ b/app/helpers/sidecar.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 from typing import Optional
 from lxml import etree
+from lxml.etree import XMLSyntaxError
 
 
 class InvalidSidecarException(Exception):
@@ -14,7 +15,10 @@ class Sidecar:
     """Class used for parsing the metadata sidecar of the essence pair."""
 
     def __init__(self, path: Path):
-        self.root = etree.parse(str(path))
+        try:
+            self.root = etree.parse(str(path))
+        except XMLSyntaxError as e:
+            raise InvalidSidecarException(f"XML syntax error: '{e}'")
         # Mandatory
         self.md5 = self.root.findtext("md5")
         if not self.md5:

--- a/tests/helpers/test_sidecar.py
+++ b/tests/helpers/test_sidecar.py
@@ -16,8 +16,18 @@ def test_sidecar():
 
 
 def test_sidecar_no_md5():
-    with pytest.raises(InvalidSidecarException):
+    with pytest.raises(InvalidSidecarException) as e:
         Sidecar(Path("tests", "resources", "sidecar", "sidecar_no_md5.xml"))
+    assert str(e.value) == "Missing mandatory key: 'md5'"
+
+
+def test_sidecar_empty():
+    with pytest.raises(InvalidSidecarException) as e:
+        Sidecar(Path("tests", "resources", "sidecar", "sidecar_empty.xml"))
+    assert (
+        str(e.value)
+        == "XML syntax error: 'Document is empty, line 1, column 1 (sidecar_empty.xml, line 1)'"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Raise a InvalidSidecarException when a (syntax) parse error occurs.

Include error reason in the log entry.