### PR TITLE
DEV-2164 Remove casing exceptions in mapping

### DIFF
--- a/app/resources/dc.xslt
+++ b/app/resources/dc.xslt
@@ -423,7 +423,7 @@
         </xsl:element>
     </xsl:template>
 
-    <xsl:template match="dc_creators/Auteur | dc_creators/auteur">
+    <xsl:template match="dc_creators/Auteur">
         <xsl:element name="dcterms:creator">
             <xsl:attribute name="schema:roleName">
                 <xsl:text>auteur</xsl:text>
@@ -648,7 +648,7 @@
     </xsl:template>
 
     <!-- Publisher-->
-    <xsl:template match="dc_publishers/Publisher | dc_publishers/publisher">
+    <xsl:template match="dc_publishers/Publisher">
         <xsl:element name="dcterms:publisher">
             <xsl:value-of select="text()" />
         </xsl:element>
@@ -706,7 +706,7 @@
     </xsl:template>
 
     <!-- Rights owner author -->
-    <xsl:template match="dc_rights_rightsOwners/Auteursrechthouder | dc_rights_rightsOwners/auteursrechthouder">
+    <xsl:template match="dc_rights_rightsOwners/Auteursrechthouder">
         <xsl:element name="dcterms:rightsHolder">
             <xsl:attribute name="schema:roleName">
                 <xsl:text>auteursrechthouder</xsl:text>
@@ -726,7 +726,7 @@
     </xsl:template>
 
     <!-- Subjects -->
-    <xsl:template match="dc_subjects/Trefwoord | dc_Subjects/Trefwoord | dc_subjects/trefwoord">
+    <xsl:template match="dc_subjects/Trefwoord | dc_Subjects/Trefwoord">
         <xsl:element name="dcterms:subject">
             <xsl:value-of select="text()" />
         </xsl:element>

--- a/tests/helpers/test_dc.py
+++ b/tests/helpers/test_dc.py
@@ -36,13 +36,6 @@ from lxml import etree
         ("metadata_description_short.xml", "dc_description_short.xml"),
         ("metadata_titles_empty_title.xml", "dc_titles_empty_title.xml"),
         ("metadata_all_empty_titles.xml", "dc_all_empty_titles.xml"),
-        ("metadata_dc_subjects_trefwoord.xml", "dc_dc_subjects_trefwoord.xml"),
-        ("metadata_dc_creators_auteur.xml", "dc_dc_creators_auteur.xml"),
-        (
-            "metadata_dc_rights_rightsOwners_auteursrechthouder.xml",
-            "dc_dc_rights_rightsOwners_auteursrechthouder.xml",
-        ),
-        ("metadata_dc_publishers_publisher.xml", "dc_dc_publishers_publisher.xml"),
     ],
 )
 def test_transform(input_file, output_file):

--- a/tests/resources/dc/dc_dc_creators_auteur.xml
+++ b/tests/resources/dc/dc_dc_creators_auteur.xml
@@ -1,3 +1,0 @@
-<metadata xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:ebucore="urn:ebu:metadata-schema:ebucore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
-  <dcterms:creator schema:roleName="auteur">auteur</dcterms:creator>
-</metadata>

--- a/tests/resources/dc/dc_dc_publishers_publisher.xml
+++ b/tests/resources/dc/dc_dc_publishers_publisher.xml
@@ -1,3 +1,0 @@
-<metadata xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:ebucore="urn:ebu:metadata-schema:ebucore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
-  <dcterms:publisher>publisher</dcterms:publisher>
-</metadata>

--- a/tests/resources/dc/dc_dc_rights_rightsOwners_auteursrechthouder.xml
+++ b/tests/resources/dc/dc_dc_rights_rightsOwners_auteursrechthouder.xml
@@ -1,3 +1,0 @@
-<metadata xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:ebucore="urn:ebu:metadata-schema:ebucore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
-  <dcterms:rightsHolder schema:roleName="auteursrechthouder">auteur</dcterms:rightsHolder>
-</metadata>

--- a/tests/resources/dc/dc_dc_subjects_trefwoord.xml
+++ b/tests/resources/dc/dc_dc_subjects_trefwoord.xml
@@ -1,5 +1,0 @@
-<metadata xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:ebucore="urn:ebu:metadata-schema:ebucore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
-  <dcterms:subject>voetbal</dcterms:subject>
-  <dcterms:subject>handbal</dcterms:subject>
-  <dcterms:subject>economie</dcterms:subject>
-</metadata>

--- a/tests/resources/dc/metadata_dc_creators_auteur.xml
+++ b/tests/resources/dc/metadata_dc_creators_auteur.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<VIAA>
-    <dc_creators>
-        <auteur>auteur</auteur>
-    </dc_creators>
-</VIAA>

--- a/tests/resources/dc/metadata_dc_publishers_publisher.xml
+++ b/tests/resources/dc/metadata_dc_publishers_publisher.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<VIAA>
-    <dc_publishers>
-        <publisher>publisher</publisher>
-    </dc_publishers>
-</VIAA>

--- a/tests/resources/dc/metadata_dc_rights_rightsOwners_auteursrechthouder.xml
+++ b/tests/resources/dc/metadata_dc_rights_rightsOwners_auteursrechthouder.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<VIAA>
-    <dc_rights_rightsOwners>
-        <auteursrechthouder>auteur</auteursrechthouder>
-    </dc_rights_rightsOwners>
-</VIAA>

--- a/tests/resources/dc/metadata_dc_subjects_trefwoord.xml
+++ b/tests/resources/dc/metadata_dc_subjects_trefwoord.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<VIAA>
-    <dc_subjects type="list">
-        <trefwoord>voetbal</trefwoord>
-        <trefwoord>handbal</trefwoord>
-        <trefwoord>economie</trefwoord>
-    </dc_subjects>
-</VIAA>


### PR DESCRIPTION
There were exceptions introduced in the mapping logic, see DEV-2136. The CP changed its metadata to not include these fields with lowercase anymore, so the exceptions can be removed from the code.