### PR TITLE
 DEV-2236 Add collaterals in SIP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.10-slim
 
 # Install mime-support
 RUN apt-get update &&\

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ## Synopsis
 
 ## Prerequisites
+ - Git
+ - Docker (optional)
+ - Python 3.10+
+ - Access to the meemoo PyPi
 
 ## Diagrams
 

--- a/app/app.py
+++ b/app/app.py
@@ -146,7 +146,7 @@ class EventListener:
             return
 
         # Regex to match essence paths in bag to fetch md5
-        regex = re.compile("data/representations/.*/data/.*")
+        regex = re.compile("data/representations/.*/data/.*\.(?!srt).*")
 
         for filepath, fixity in bag.entries.items():
             if regex.match(filepath):

--- a/app/app.py
+++ b/app/app.py
@@ -101,6 +101,7 @@ class EventListener:
 
         essence_path = message.get_essence_path()
         xml_path = message.get_xml_path()
+        collaterals_paths = message.get_collateral_paths()
 
         # Check if essence and XML file exist
         if not essence_path.exists() or not xml_path.exists():
@@ -126,6 +127,8 @@ class EventListener:
             "essence_filename": essence_path.name,
             "cp_id": message.flow_id,
             "essence_filesize": essence_filesize,
+            "has_collaterals": bool(collaterals_paths),
+            "collateral_filenames": [path.name for path in collaterals_paths],
         }
 
         # Parse sidecar

--- a/app/helpers/bag.py
+++ b/app/helpers/bag.py
@@ -6,7 +6,6 @@ import shutil
 import zipfile
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Tuple
 
 import bagit
 from lxml import etree
@@ -91,7 +90,7 @@ MIMETYPE_TYPE_MAP = {
 }
 
 
-def guess_mimetype(file: Path) -> Optional[str]:
+def guess_mimetype(file: Path) -> str | None:
     """Calculate the mimetype of a path based on the extension.
 
     Args:
@@ -561,7 +560,7 @@ class Bag:
             pretty_print=True,
         )
 
-    def create_sip_bag(self) -> Tuple[Path, bagit.Bag]:
+    def create_sip_bag(self) -> tuple[Path, bagit.Bag]:
         """Create the SIP in the bag format.
 
         - Create the minimal SIP

--- a/app/helpers/bag.py
+++ b/app/helpers/bag.py
@@ -592,7 +592,6 @@ class Bag:
         """
         essence_path: Path = self.watchfolder_message.get_essence_path()
         xml_path: Path = self.watchfolder_message.get_xml_path()
-        collaterals: Path = self.watchfolder_message.get_collateral_paths()
         if not essence_path.exists() or not xml_path.exists():
             # TODO: raise error
             return

--- a/app/helpers/events.py
+++ b/app/helpers/events.py
@@ -4,7 +4,6 @@
 import json
 from pathlib import Path
 from json import JSONDecodeError
-from typing import List, Union
 
 
 class InvalidMessageException(Exception):
@@ -53,7 +52,7 @@ class WatchfolderMessage:
         except KeyError as e:
             raise InvalidMessageException(f"Missing mandatory key: {e}")
 
-    def _get_files(self, file_type: str) -> Union[SIPItem, List[SIPItem]]:
+    def _get_files(self, file_type: str) -> SIPItem | list[SIPItem]:
         """Return the SIPItem(s) of a file in the incoming SIP.
 
         Only the type 'sidecar', 'essence' or 'collateral' is allowed.

--- a/app/helpers/events.py
+++ b/app/helpers/events.py
@@ -4,6 +4,7 @@
 import json
 from pathlib import Path
 from json import JSONDecodeError
+from typing import List, Union
 
 
 class InvalidMessageException(Exception):
@@ -40,27 +41,36 @@ class WatchfolderMessage:
             self.cp_name = msg["cp_name"]
             self.flow_id = msg["flow_id"]
             self.files = {}
+            collaterals = []
             for sip_package in msg["sip_package"]:
-                self.files[sip_package["file_type"]] = SIPItem(sip_package)
+                if sip_package["file_type"] == "collateral":
+                    collaterals.append(SIPItem(sip_package))
+                else:
+                    self.files[sip_package["file_type"]] = SIPItem(sip_package)
+
+            self.files["collateral"] = collaterals
 
         except KeyError as e:
             raise InvalidMessageException(f"Missing mandatory key: {e}")
 
-    def _get_file(self, file_type: str) -> SIPItem:
-        """Return the SIPItem of a file in the incoming SIP.
+    def _get_files(self, file_type: str) -> Union[SIPItem, List[SIPItem]]:
+        """Return the SIPItem(s) of a file in the incoming SIP.
 
-        Only the type 'sidecar' or 'essence' is allowed.
+        Only the type 'sidecar', 'essence' or 'collateral' is allowed.
+
+        There should be only one file of type 'sidecar' and 'essence'.
+        It is possible to have multiple files op type 'collateral'.
 
         Args:
             file_type: The type of the file.
 
-        Returns: The SIPItem.
+        Returns: The SIPItem(s).
         """
         try:
             return self.files[file_type]
         except KeyError:
             raise ValueError(
-                "Not a valid file type of the incoming SIP: {file_type}. Only 'sidecar' or 'essence' is allowed"
+                "Not a valid file type of the incoming SIP: {file_type}. Only 'sidecar', 'essence' or 'collateral' is allowed"
             )
 
     def get_essence_path(self) -> Path:
@@ -68,7 +78,7 @@ class WatchfolderMessage:
 
         Returns: The essence file as a Path.
         """
-        file = self._get_file("essence")
+        file = self._get_files("essence")
         return Path(file.file_path, file.file_name)
 
     def get_xml_path(self) -> Path:
@@ -77,5 +87,15 @@ class WatchfolderMessage:
         Returns: The metadata file as a Path.
         """
 
-        file = self._get_file("sidecar")
+        file = self._get_files("sidecar")
         return Path(file.file_path, file.file_name)
+
+    def get_collateral_paths(self) -> list[Path]:
+        """Return the paths of the collateral files.
+
+        Returns: The collateral files as list of Paths.
+        """
+        return [
+            Path(file.file_path, file.file_name)
+            for file in self._get_files("collateral")
+        ]

--- a/app/helpers/mets.py
+++ b/app/helpers/mets.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 from datetime import datetime
 from enum import Enum
-from typing import Union, Optional
 from uuid import uuid4
 
 from lxml import etree
@@ -224,7 +223,7 @@ class File:
         self.children = []
         self.is_mets = is_mets
 
-    def is_fptr(self) -> Union[bool, Optional]:
+    def is_fptr(self) -> bool | None:
         """Calculates if a file is a fptr or a mptr
 
         If a file points to a METS file, it is a mptr (METS pointer).

--- a/app/helpers/premis.py
+++ b/app/helpers/premis.py
@@ -26,6 +26,8 @@ class RelationshipSubtype(Enum):
     REPRESENTED_BY = "is represented by"
     REPRESENTS = "represents"
     INCLUDED_IN = "is included in"
+    IS_REQUIRED_BY = "is required by"
+    REQUIRES = "requires"
 
 
 class ObjectType(Enum):
@@ -139,11 +141,13 @@ class Relationship:
         RelationshipSubtype.REPRESENTED_BY: "isr",
         RelationshipSubtype.REPRESENTS: "rep",
         RelationshipSubtype.INCLUDED_IN: "isi",
+        RelationshipSubtype.IS_REQUIRED_BY: "irq",
+        RelationshipSubtype.REQUIRES: "req",
     }
 
-    def __init__(self, subtype: RelationshipSubtype, uuid: str):
+    def __init__(self, subtype: RelationshipSubtype, uuids: list[str]):
         self.subtype = subtype
-        self.uuid = uuid
+        self.uuids = uuids
 
     def to_element(self):
         """Returns the relationship node as an lxml element.
@@ -180,7 +184,8 @@ class Relationship:
         ).text = self.subtype.value
 
         # Related object identifier
-        relationship_element.append(RelatedObjectIdentifier(self.uuid).to_element())
+        for uuid in self.uuids:
+            relationship_element.append(RelatedObjectIdentifier(uuid).to_element())
 
         return relationship_element
 

--- a/app/helpers/premis.py
+++ b/app/helpers/premis.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from enum import Enum
-from typing import List, Optional
 
 from lxml import etree
 
@@ -299,11 +298,11 @@ class Object:
     def __init__(
         self,
         type: ObjectType,
-        identifiers: List[ObjectIdentifier],
-        original_name: Optional[OriginalName] = None,
-        fixity: Optional[Fixity] = None,
-        relationships: Optional[List[Relationship]] = None,
-        storages: Optional[List[Storage]] = None,
+        identifiers: list[ObjectIdentifier],
+        original_name: OriginalName | None = None,
+        fixity: Fixity | None = None,
+        relationships: list[Relationship] | None = None,
+        storages: list[Storage] | None = None,
     ):
         self.type: ObjectType = type
         self.identifiers = identifiers
@@ -466,12 +465,12 @@ class Agent:
 
     def __init__(
         self,
-        identifiers: List[AgentIdentifier],
+        identifiers: list[AgentIdentifier],
         type: str = "",
         name: str = "",
-        extension: Optional[AgentExtension] = None,
+        extension: AgentExtension | None = None,
     ):
-        self.identifiers: List[AgentIdentifier] = identifiers
+        self.identifiers: list[AgentIdentifier] = identifiers
         self.type = type
         self.name = name
         self.extension = extension
@@ -554,7 +553,7 @@ class LinkingAgentIdentifier:
         roles: The roles of the linking agent identifier."""
 
     def __init__(
-        self, type: str, value: str, roles: Optional[List[LinkingAgentRole]] = None
+        self, type: str, value: str, roles: list[LinkingAgentRole] | None = None
     ):
         self.type = type
         self.value = value
@@ -631,7 +630,7 @@ class LinkingObjectIdentifier:
         rol: The roles of the linking object identifier."""
 
     def __init__(
-        self, type: str, value: str, roles: Optional[List[LinkingObjectRole]] = None
+        self, type: str, value: str, roles: list[LinkingObjectRole] | None = None
     ):
         self.type = type
         self.value = value
@@ -752,9 +751,9 @@ class Event:
         identifier: EventIdentifier,
         type: str,
         date_time: str,
-        event_detail_informations: Optional[List[EventDetailInformation]] = None,
-        linking_agent_identifiers: Optional[List[LinkingAgentIdentifier]] = None,
-        linking_object_identifiers: Optional[List[LinkingObjectIdentifier]] = None,
+        event_detail_informations: list[EventDetailInformation] | None = None,
+        linking_agent_identifiers: list[LinkingAgentIdentifier] | None = None,
+        linking_object_identifiers: list[LinkingObjectIdentifier] | None = None,
     ):
         self.identifier = identifier
         self.type = type
@@ -814,9 +813,9 @@ class Premis:
     ATTRS = {"version": "3.0"}
 
     def __init__(self):
-        self.objects: List[Object] = []
-        self.events: List[Event] = []
-        self.agents: List[Agent] = []
+        self.objects: list[Object] = []
+        self.events: list[Event] = []
+        self.agents: list[Agent] = []
 
     def add_object(self, object: Object):
         self.objects.append(object)

--- a/app/helpers/sidecar.py
+++ b/app/helpers/sidecar.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from pathlib import Path
-from typing import Optional
 from lxml import etree
 from lxml.etree import XMLSyntaxError
 
@@ -53,7 +52,7 @@ class Sidecar:
         # Batch ID
         self.batch_id = self.root.findtext("batch_id")
 
-    def calculate_original_filename(self) -> Optional[str]:
+    def calculate_original_filename(self) -> str | None:
         """Calculate the original filename.
 
         Give preference to the "bestandsnaam" field in the "dc_identifiers_localids"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@ PyYAML==6.0
 structlog==21.5.0
 viaa-chassis==0.2.0rc1
 bagit==1.8.1
-pulsar-client==2.8.1
+pulsar-client==2.10.0
 meemoo-cloudevents==0.1.0rc3
 lxml==4.7.1
 requests==2.28.0
 # Dev
-black==21.12b0
+black==22.10.0
 flake8==4.0.1
 # Test
 pytest==6.2.5

--- a/tests/helpers/test_bag.py
+++ b/tests/helpers/test_bag.py
@@ -31,6 +31,7 @@ from app.helpers.bag import guess_mimetype, calculate_sip_type
         (".psb", "application/vnd.adobe.photoshop"),
         (".mpeg", "video/mpeg"),
         (".mts", "video/MP2T"),
+        (".srt", "text/plain"),
     ],
 )
 def test_guess_mimetype(extension, mimetype):

--- a/tests/helpers/test_events.py
+++ b/tests/helpers/test_events.py
@@ -20,11 +20,11 @@ def test_message_valid():
     event = WatchfolderMessage(_load_resource("message.json"))
     assert event.cp_name == "CPFIELD"
     assert event.flow_id == "FLOWFIELD"
-    essence_file = event._get_file("essence")
+    essence_file = event._get_files("essence")
     assert essence_file.file_name == "file.mxf"
     assert essence_file.file_path == "/path/to/essence/file"
 
-    xml_file = event._get_file("sidecar")
+    xml_file = event._get_files("sidecar")
     assert xml_file.file_name == "file.xml"
     assert xml_file.file_path == "/path/to/xml/file"
 
@@ -47,6 +47,14 @@ def test_message_missing_key():
 def test_get_essence_path():
     event = WatchfolderMessage(_load_resource("message.json"))
     assert event.get_essence_path() == Path("/path/to/essence/file/file.mxf")
+
+
+def test_get_collateral_paths():
+    event = WatchfolderMessage(_load_resource("message_collaterals.json"))
+    assert event.get_collateral_paths() == [
+        Path("/path/to/srt/file/sub1.srt"),
+        Path("/path/to/srt/file/sub2.srt"),
+    ]
 
 
 def test_get_xml_path():

--- a/tests/resources/watchfolder/message_collaterals.json
+++ b/tests/resources/watchfolder/message_collaterals.json
@@ -1,0 +1,36 @@
+{
+    "cp_name": "CPFIELD",
+    "flow_id": "FLOWFIELD",
+    "server": "someserver",
+    "username": "someusername",
+    "password": "somepassword",
+    "timestamp": "2017-09-01T16:23:30.072+02:00",
+    "sip_package": [
+        {
+            "file_name": "file.mxf",
+            "file_path": "/path/to/essence/file",
+            "file_type": "essence",
+            "md5": "5",
+            "timestamp": "2017-09-01T16:23:30.084+02:00"
+        },
+        {
+            "file_name": "file.xml",
+            "file_path": "/path/to/xml/file",
+            "file_type": "sidecar",
+            "md5": "1",
+            "timestamp": "2017-09-01T16:23:30.091+02:00"
+        },
+        {
+            "file_type": "collateral",
+            "file_path": "/path/to/srt/file",
+            "file_name": "sub1.srt",
+            "timestamp": "2017-09-01T16:23:30.091+02:00"
+        },
+        {
+            "file_type": "collateral",
+            "file_path": "/path/to/srt/file",
+            "file_name": "sub2.srt",
+            "timestamp": "2017-09-01T16:23:30.091+02:00"
+        }
+    ]
+}


### PR DESCRIPTION
Add collaterals in SIP: 
 - Copy collaterals to the data folder.
 - Write collateral info in:
   - the METS on representation level;
   - the preservation metadata on representation level.

Other things:
 - Refactor some logic in `bag.py`.
 - Add required PREMIS relationship subtypes.
 - PREMIS relationship can reference multiple uuids.
 - Add `.srt` in mimetype map.
 - Use simplified typing hints introduced in Python 3.9 and 3.10. Bump Docker version to Python 3.10.
 - Change Pulsar client version to the same as the Pulsar server (2.10.0).
 - Bump Black version to the latest non-beta version.
 - Add prerequisites section in README.md.