### PR TITLE
DEV-2248 Add dc_creators/Geïnterviewde in mapping

### DIFF
--- a/app/helpers/bag.py
+++ b/app/helpers/bag.py
@@ -427,6 +427,7 @@ class Bag:
         etree.ElementTree(dc_terms).write(
             str(metadata_desc_folder.joinpath("dc.xml")),
             pretty_print=True,
+            encoding="utf-8",
         )
 
         # /metadata/preservation/

--- a/app/resources/dc.xslt
+++ b/app/resources/dc.xslt
@@ -582,6 +582,15 @@
         </xsl:element>
     </xsl:template>
 
+    <xsl:template match="dc_creators/Geïnterviewde">
+        <xsl:element name="dcterms:creator">
+            <xsl:attribute name="schema:roleName">
+                <xsl:text>geïnterviewde</xsl:text>
+            </xsl:attribute>
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+
     <!-- Description -->
     <xsl:template match="dc_description">
         <xsl:element name="dcterms:description">

--- a/tests/helpers/test_dc.py
+++ b/tests/helpers/test_dc.py
@@ -44,7 +44,9 @@ def test_transform(input_file, output_file):
     # Act
     terms_element = DC.transform(medadata_path)
     # Assert
-    terms_xml = etree.tostring(terms_element, pretty_print=True).strip()
+    terms_xml = etree.tostring(
+        terms_element, pretty_print=True, encoding="utf-8"
+    ).strip()
     xml = load_resource(Path("tests", "resources", "dc", output_file))
     assert terms_xml == xml
 
@@ -58,6 +60,8 @@ def test_transform_uuid():
         ie_uuid=etree.XSLT.strparam("uuid-865b767d-05f9-49d5-ba54-e9e82acec30d"),
     )
     # Assert
-    terms_xml = etree.tostring(terms_element, pretty_print=True).strip()
+    terms_xml = etree.tostring(
+        terms_element, pretty_print=True, encoding="utf-8"
+    ).strip()
     xml = load_resource(Path("tests", "resources", "dc", "dc.xml"))
     assert terms_xml == xml

--- a/tests/resources/dc/dc.xml
+++ b/tests/resources/dc/dc.xml
@@ -94,6 +94,7 @@
   <dcterms:creator schema:roleName="productiehuis">Productiehuis</dcterms:creator>
   <dcterms:creator schema:roleName="regisseur">Regisseur</dcterms:creator>
   <dcterms:creator schema:roleName="schrijver">Schrijver</dcterms:creator>
+  <dcterms:creator schema:roleName="geïnterviewde">Geïnterviewde</dcterms:creator>
   <dcterms:abstract>Abstract</dcterms:abstract>
   <schema:caption>Caption</schema:caption>
   <schema:transcript>Transcript</schema:transcript>

--- a/tests/resources/dc/metadata.xml
+++ b/tests/resources/dc/metadata.xml
@@ -126,6 +126,7 @@
         <Productiehuis>Productiehuis</Productiehuis>
         <Regisseur>Regisseur</Regisseur>
         <Schrijver>Schrijver</Schrijver>
+        <Geïnterviewde>Geïnterviewde</Geïnterviewde>
     </dc_creators>
     <dc_description_lang>Abstract</dc_description_lang>
     <dc_description_ondertitels>Caption</dc_description_ondertitels>


### PR DESCRIPTION
Write out the dc.xml in utf-8 encoding so that the `ï` can be properly encoded. The default is `US-ASCII` which doesn't encode `ï`.