### PR TITLE
DEV-2266 Add .mkv to mimetype map

### DIFF
--- a/app/helpers/bag.py
+++ b/app/helpers/bag.py
@@ -71,6 +71,7 @@ EXTENSION_MIMETYPE_MAP = {
     ".mpeg": "video/mpeg",
     ".mts": "video/MP2T",
     ".srt": "text/plain",
+    ".mkv": "video/x-matroska",
 }
 
 MIMETYPE_TYPE_MAP = {
@@ -88,6 +89,7 @@ MIMETYPE_TYPE_MAP = {
     "video/mpeg": "Video - File-based and Physical Media",
     "application/mxf": "Video - File-based and Physical Media",
     "application/vnd.adobe.photoshop": "Photographs - Digital",
+    "video/x-matroska": "Video - File-based and Physical Media",
 }
 
 

--- a/tests/helpers/test_bag.py
+++ b/tests/helpers/test_bag.py
@@ -32,6 +32,7 @@ from app.helpers.bag import guess_mimetype, calculate_sip_type
         (".mpeg", "video/mpeg"),
         (".mts", "video/MP2T"),
         (".srt", "text/plain"),
+        (".mkv", "video/x-matroska"),
     ],
 )
 def test_guess_mimetype(extension, mimetype):
@@ -65,6 +66,7 @@ def test_guess_mimetype_other():
         ("video/mpeg", "Video - File-based and Physical Media"),
         ("application/mxf", "Video - File-based and Physical Media"),
         ("application/vnd.adobe.photoshop", "Photographs - Digital"),
+        ("video/x-matroska", "Video - File-based and Physical Media"),
     ],
 )
 def test_calculate_sip_type(mimetype, sip_type):


### PR DESCRIPTION
Add .mkv extension to the mimetype map. Although this extension is not allowed in the watchfolders, it can be send via the batch intake.