### PR TITLE
DEV-2290 Add .avi to mimetype map

### DIFF
--- a/app/helpers/bag.py
+++ b/app/helpers/bag.py
@@ -72,6 +72,7 @@ EXTENSION_MIMETYPE_MAP = {
     ".mts": "video/MP2T",
     ".srt": "text/plain",
     ".mkv": "video/x-matroska",
+    ".avi": "video/x-msvideo",
 }
 
 MIMETYPE_TYPE_MAP = {
@@ -90,6 +91,7 @@ MIMETYPE_TYPE_MAP = {
     "application/mxf": "Video - File-based and Physical Media",
     "application/vnd.adobe.photoshop": "Photographs - Digital",
     "video/x-matroska": "Video - File-based and Physical Media",
+    "video/x-msvideo": "Video - File-based and Physical Media",
 }
 
 

--- a/tests/helpers/test_bag.py
+++ b/tests/helpers/test_bag.py
@@ -33,6 +33,7 @@ from app.helpers.bag import guess_mimetype, calculate_sip_type
         (".mts", "video/MP2T"),
         (".srt", "text/plain"),
         (".mkv", "video/x-matroska"),
+        (".avi", "video/x-msvideo"),
     ],
 )
 def test_guess_mimetype(extension, mimetype):
@@ -67,6 +68,7 @@ def test_guess_mimetype_other():
         ("application/mxf", "Video - File-based and Physical Media"),
         ("application/vnd.adobe.photoshop", "Photographs - Digital"),
         ("video/x-matroska", "Video - File-based and Physical Media"),
+        ("video/x-msvideo", "Video - File-based and Physical Media"),
     ],
 )
 def test_calculate_sip_type(mimetype, sip_type):


### PR DESCRIPTION
Add .avi extension to the mimetype map. Although this extension is not allowed in the watchfolders, it can be sent via batch intake.