### PR TITLE
DEV-2291 Fix filename of zipped bag

### DIFF
--- a/app/helpers/bag.py
+++ b/app/helpers/bag.py
@@ -805,7 +805,7 @@ class Bag:
         bag = bagit.make_bag(root_folder, bag_info=bag_info, checksums=["md5"])
 
         # Zip bag
-        bag_path = root_folder.with_suffix(".bag.zip")
+        bag_path = Path(f"{root_folder}.bag.zip")
         with zipfile.ZipFile(bag_path, mode="w") as archive:
             for file_path in root_folder.rglob("*"):
                 archive.write(file_path, arcname=file_path.relative_to(root_folder))


### PR DESCRIPTION
The filename of the zipped bag should be derived from the filename of the essence/sidecar.

For example, if the essence has the filename `file.111.mkv`, then the filename of the zip should be `file.111.bag.zip`.

The `with_suffix` method in the Pathlib library however replaces the suffix resulting in `file.bag.zip`.

Just append the filename with `.bag.zip`.