### PR TITLE
DEV-2531 Strip whitespace from sidecar md5 hash

### DIFF
--- a/app/helpers/sidecar.py
+++ b/app/helpers/sidecar.py
@@ -10,10 +10,10 @@ from lxml.etree import XMLSyntaxError
 def optional_chain_strip(opt_str: Optional[str]) -> Optional[str]:
     """
     Strips unicode whitespace characters if parameter is not None. Else, returns None.
-    """ 
+    """
     if opt_str is None:
         return None
-    
+
     return opt_str.strip()
 
 
@@ -37,7 +37,7 @@ class Sidecar:
         if not md5:
             raise InvalidSidecarException("Missing mandatory key: 'md5'")
         self.md5 = md5
-        
+
         # Optional
         self.cp_id = self.root.findtext("CP_id")
         self.dc_source = self.root.findtext("dc_source")

--- a/tests/helpers/test_sidecar.py
+++ b/tests/helpers/test_sidecar.py
@@ -21,6 +21,17 @@ def test_sidecar_no_md5():
     assert str(e.value) == "Missing mandatory key: 'md5'"
 
 
+def test_sidecar_md5_with_only_whitespace():
+    with pytest.raises(InvalidSidecarException) as e:
+        Sidecar(Path("tests", "resources", "sidecar", "sidecar_md5_with_only_whitespace.xml"))
+    assert str(e.value) == "Missing mandatory key: 'md5'"
+
+
+def test_sidecar_md5_with_surrounding_whitespace():
+    sidecar = Sidecar(Path("tests", "resources", "sidecar", "sidecar_md5_with_surrounding_whitespace.xml"))
+    assert sidecar.md5 == "7e0ef8c24fe343d98fbb93b6a7db6ccb"
+
+
 def test_sidecar_empty():
     with pytest.raises(InvalidSidecarException) as e:
         Sidecar(Path("tests", "resources", "sidecar", "sidecar_empty.xml"))

--- a/tests/helpers/test_sidecar.py
+++ b/tests/helpers/test_sidecar.py
@@ -23,12 +23,23 @@ def test_sidecar_no_md5():
 
 def test_sidecar_md5_with_only_whitespace():
     with pytest.raises(InvalidSidecarException) as e:
-        Sidecar(Path("tests", "resources", "sidecar", "sidecar_md5_with_only_whitespace.xml"))
+        Sidecar(
+            Path(
+                "tests", "resources", "sidecar", "sidecar_md5_with_only_whitespace.xml"
+            )
+        )
     assert str(e.value) == "Missing mandatory key: 'md5'"
 
 
 def test_sidecar_md5_with_surrounding_whitespace():
-    sidecar = Sidecar(Path("tests", "resources", "sidecar", "sidecar_md5_with_surrounding_whitespace.xml"))
+    sidecar = Sidecar(
+        Path(
+            "tests",
+            "resources",
+            "sidecar",
+            "sidecar_md5_with_surrounding_whitespace.xml",
+        )
+    )
     assert sidecar.md5 == "7e0ef8c24fe343d98fbb93b6a7db6ccb"
 
 

--- a/tests/resources/sidecar/sidecar_md5_with_only_whitespace.xml
+++ b/tests/resources/sidecar/sidecar_md5_with_only_whitespace.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<VIAA xmlns:xalan="http://xml.apache.org">
+    <CP>CP</CP>
+    <CP_id>CP ID</CP_id>
+    <dc_identifier_localid>localid</dc_identifier_localid>
+    <md5>
+         
+    </md5>
+    <dc_title>title</dc_title>
+    <dcterms_created>2022-01-28</dcterms_created>
+    <dc_Subjects type="list">
+        <Trefwoord>subject</Trefwoord>
+    </dc_Subjects>
+    <dc_description>description</dc_description>
+</VIAA>

--- a/tests/resources/sidecar/sidecar_md5_with_surrounding_whitespace.xml
+++ b/tests/resources/sidecar/sidecar_md5_with_surrounding_whitespace.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<VIAA xmlns:xalan="http://xml.apache.org">
+    <CP>CP</CP>
+    <CP_id>CP ID</CP_id>
+    <dc_identifier_localid>localid</dc_identifier_localid>
+    <md5>
+        7e0ef8c24fe343d98fbb93b6a7db6ccb
+    </md5>
+    <dc_title>title</dc_title>
+    <dcterms_created>2022-01-28</dcterms_created>
+    <dc_Subjects type="list">
+        <Trefwoord>subject</Trefwoord>
+    </dc_Subjects>
+    <dc_description>description</dc_description>
+</VIAA>


### PR DESCRIPTION
Strip whitespace from md5 hashes when parsing sidecar XML to increase robustness of ingest.